### PR TITLE
BSM geospatial query

### DIFF
--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepository.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepository.java
@@ -2,11 +2,9 @@ package us.dot.its.jpo.ode.api.accessors.bsm;
 
 import java.util.List;
 
-import org.springframework.data.mongodb.core.query.Query;
-
 import us.dot.its.jpo.ode.api.models.DataLoader;
 import us.dot.its.jpo.ode.model.OdeBsmData;
 
 public interface OdeBsmJsonRepository extends DataLoader<OdeBsmData>{
-    List<OdeBsmData> findOdeBsmDataGeo(String originIp, String vehicleId, Long startTime, Long endTime, Double longitude, Double latitude);  
+    List<OdeBsmData> findOdeBsmDataGeo(String originIp, String vehicleId, Long startTime, Long endTime, Double longitude, Double latitude, Double distance);  
 }

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepository.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepository.java
@@ -13,4 +13,6 @@ public interface OdeBsmJsonRepository extends DataLoader<OdeBsmData>{
     long getQueryResultCount(Query query);
     
     List<OdeBsmData> findOdeBsmData(Query query);  
+
+    List<OdeBsmData> findOdeBsmDataGeo(String originIp, String vehicleId, Long startTime, Long endTime, Double longitude, Double latitude);  
 }

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepository.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepository.java
@@ -8,11 +8,5 @@ import us.dot.its.jpo.ode.api.models.DataLoader;
 import us.dot.its.jpo.ode.model.OdeBsmData;
 
 public interface OdeBsmJsonRepository extends DataLoader<OdeBsmData>{
-    Query getQuery(String originIp, String vehicle_id, Long startTime, Long endTime);
-
-    long getQueryResultCount(Query query);
-    
-    List<OdeBsmData> findOdeBsmData(Query query);  
-
     List<OdeBsmData> findOdeBsmDataGeo(String originIp, String vehicleId, Long startTime, Long endTime, Double longitude, Double latitude);  
 }

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepositoryImpl.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.awt.geom.Point2D;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -26,6 +27,25 @@ public class OdeBsmJsonRepositoryImpl  implements OdeBsmJsonRepository{
 
     private String collectionName = "OdeBsmJson";
 
+    public static Double[] calculateLatitudes(Double centerLatitude, Double radiusInMeters) {
+        Double latDiff = radiusInMeters / 111319.9; // Approximate degrees latitude per meter
+        Double[] latitudes = {
+            centerLatitude - latDiff,
+
+            centerLatitude + latDiff
+        };
+        return latitudes;
+    }
+
+    public static Double[] calculateLongitudes(Double centerLongitude, Double centerLatitude, Double radiusInMeters) {
+        Double lonDiff = radiusInMeters / (111319.9 * Math.cos(Math.toRadians(centerLatitude)));
+        Double[] longitudes = {
+            centerLongitude - lonDiff,
+            centerLongitude + lonDiff
+        };
+        return longitudes;
+    }
+
     public Query getQuery(String originIp, String vehicleId, Long startTime, Long endTime){
         Query query = new Query();
 
@@ -46,7 +66,7 @@ public class OdeBsmJsonRepositoryImpl  implements OdeBsmJsonRepository{
         if(endTime != null){
             endTimeString = Instant.ofEpochMilli(endTime).toString();
         }
-	query.limit(10000);
+	    query.limit(10000);
         query.addCriteria(Criteria.where("metadata.odeReceivedAt").gte(startTimeString).lte(endTimeString));
         return query;
     }
@@ -64,6 +84,47 @@ public class OdeBsmJsonRepositoryImpl  implements OdeBsmJsonRepository{
             convertedList.add(bsm);
         }
         return convertedList;
+    }
+
+
+    public List<OdeBsmData> findOdeBsmDataGeo(String originIp, String vehicleId, Long startTime, Long endTime, Double longitude, Double latitude){
+        Query query = new Query();
+
+        if(originIp != null){
+            query.addCriteria(Criteria.where("metadata.originIp").is(originIp));
+        }
+
+        if(vehicleId != null){
+            query.addCriteria(Criteria.where("payload.data.coreData.id").is(vehicleId));
+        }
+
+        String startTimeString = Instant.ofEpochMilli(0).toString();
+        String endTimeString = Instant.now().toString();
+
+        if(startTime != null){
+            startTimeString = Instant.ofEpochMilli(startTime).toString(); 
+        }
+        if(endTime != null){
+            endTimeString = Instant.ofEpochMilli(endTime).toString();
+        }
+	    query.limit(10000);
+        query.addCriteria(Criteria.where("metadata.odeReceivedAt").gte(startTimeString).lte(endTimeString));
+
+        Double[] latitudes = calculateLatitudes(latitude, 5000.0);
+        Double[] longitudes = calculateLongitudes(longitude, latitude, 5000.0);
+
+        query.addCriteria(Criteria.where("payload.data.coreData.position.latitude").gte(Math.min(latitudes[0], latitudes[1])).lte(Math.max(latitudes[0], latitudes[1])));
+        query.addCriteria(Criteria.where("payload.data.coreData.position.longitude").gte(Math.min(longitudes[0], longitudes[1])).lte(Math.max(longitudes[0], longitudes[1])));
+        
+        List<Map> documents = mongoTemplate.find(query, Map.class, collectionName);
+        List<OdeBsmData> convertedList = new ArrayList<>();
+        for(Map document : documents){
+            document.remove("_id");
+            OdeBsmData bsm = mapper.convertValue(document, OdeBsmData.class);
+            convertedList.add(bsm);
+        }
+        return convertedList;
+
     }
 
     @Override

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepositoryImpl.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepositoryImpl.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.awt.geom.Point2D;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -45,47 +44,6 @@ public class OdeBsmJsonRepositoryImpl  implements OdeBsmJsonRepository{
         };
         return longitudes;
     }
-
-    public Query getQuery(String originIp, String vehicleId, Long startTime, Long endTime){
-        Query query = new Query();
-
-        if(originIp != null){
-            query.addCriteria(Criteria.where("metadata.originIp").is(originIp));
-        }
-
-        if(vehicleId != null){
-            query.addCriteria(Criteria.where("payload.data.coreData.id").is(vehicleId));
-        }
-
-        String startTimeString = Instant.ofEpochMilli(0).toString();
-        String endTimeString = Instant.now().toString();
-
-        if(startTime != null){
-            startTimeString = Instant.ofEpochMilli(startTime).toString(); 
-        }
-        if(endTime != null){
-            endTimeString = Instant.ofEpochMilli(endTime).toString();
-        }
-	    query.limit(10000);
-        query.addCriteria(Criteria.where("metadata.odeReceivedAt").gte(startTimeString).lte(endTimeString));
-        return query;
-    }
-
-    public long getQueryResultCount(Query query){
-        return mongoTemplate.count(query, OdeBsmData.class, collectionName);
-    }
-
-    public List<OdeBsmData> findOdeBsmData(Query query) {
-        List<Map> documents = mongoTemplate.find(query, Map.class, collectionName);
-        List<OdeBsmData> convertedList = new ArrayList<>();
-        for(Map document : documents){
-            document.remove("_id");
-            OdeBsmData bsm = mapper.convertValue(document, OdeBsmData.class);
-            convertedList.add(bsm);
-        }
-        return convertedList;
-    }
-
 
     public List<OdeBsmData> findOdeBsmDataGeo(String originIp, String vehicleId, Long startTime, Long endTime, Double longitude, Double latitude){
         Query query = new Query();

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepositoryImpl.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/bsm/OdeBsmJsonRepositoryImpl.java
@@ -109,13 +109,13 @@ public class OdeBsmJsonRepositoryImpl  implements OdeBsmJsonRepository{
         }
 	    query.limit(10000);
         query.addCriteria(Criteria.where("metadata.odeReceivedAt").gte(startTimeString).lte(endTimeString));
+        if (longitude!=-1.0 && latitude!=-1.0){
+            Double[] latitudes = calculateLatitudes(latitude, 5000.0);
+            Double[] longitudes = calculateLongitudes(longitude, latitude, 5000.0);
 
-        Double[] latitudes = calculateLatitudes(latitude, 5000.0);
-        Double[] longitudes = calculateLongitudes(longitude, latitude, 5000.0);
-
-        query.addCriteria(Criteria.where("payload.data.coreData.position.latitude").gte(Math.min(latitudes[0], latitudes[1])).lte(Math.max(latitudes[0], latitudes[1])));
-        query.addCriteria(Criteria.where("payload.data.coreData.position.longitude").gte(Math.min(longitudes[0], longitudes[1])).lte(Math.max(longitudes[0], longitudes[1])));
-        
+            query.addCriteria(Criteria.where("payload.data.coreData.position.latitude").gte(Math.min(latitudes[0], latitudes[1])).lte(Math.max(latitudes[0], latitudes[1])));
+            query.addCriteria(Criteria.where("payload.data.coreData.position.longitude").gte(Math.min(longitudes[0], longitudes[1])).lte(Math.max(longitudes[0], longitudes[1])));
+        }
         List<Map> documents = mongoTemplate.find(query, Map.class, collectionName);
         List<OdeBsmData> convertedList = new ArrayList<>();
         for(Map document : documents){

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/ProcessedMapRepositoryImpl.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/ProcessedMapRepositoryImpl.java
@@ -93,26 +93,28 @@ public class ProcessedMapRepositoryImpl implements ProcessedMapRepository {
 
         while (results.hasNext()) {
             Integer intersectionId = results.next();
-            Bson projectionFields = Projections.fields(
-                    Projections.include("properties.intersectionId", "properties.originIp",
-                            "properties.refPoint.latitude", "properties.refPoint.longitude"),
-                    Projections.excludeId());
-            Document document = collection.find(eq("properties.intersectionId", intersectionId))
-                    .projection(projectionFields).sort(Sorts.descending("properties.timeStamp")).first();
-            IntersectionReferenceData data = new IntersectionReferenceData();
-            Document properties = document.get("properties", Document.class);
+                if (intersectionId != null){
+                Bson projectionFields = Projections.fields(
+                        Projections.include("properties.intersectionId", "properties.originIp",
+                                "properties.refPoint.latitude", "properties.refPoint.longitude"),
+                        Projections.excludeId());
+                Document document = collection.find(eq("properties.intersectionId", intersectionId))
+                        .projection(projectionFields).sort(Sorts.descending("properties.timeStamp")).first();
+                IntersectionReferenceData data = new IntersectionReferenceData();
+                Document properties = document.get("properties", Document.class);
 
-            if (properties != null) {
-                Document refPoint = properties.get("refPoint", Document.class);
-                data.setIntersectionID(intersectionId);
-                data.setRoadRegulatorID("-1");
-                data.setRsuIP(properties.getString("originIp"));
-                if (refPoint != null) {
-                    data.setLatitude(refPoint.getDouble("latitude"));
-                    data.setLongitude(refPoint.getDouble("longitude"));
+                if (properties != null) {
+                    Document refPoint = properties.get("refPoint", Document.class);
+                    data.setIntersectionID(intersectionId);
+                    data.setRoadRegulatorID("-1");
+                    data.setRsuIP(properties.getString("originIp"));
+                    if (refPoint != null) {
+                        data.setLatitude(refPoint.getDouble("latitude"));
+                        data.setLongitude(refPoint.getDouble("longitude"));
+                    }
                 }
+                referenceDataList.add(data);
             }
-            referenceDataList.add(data);
         }
 
         return referenceDataList;

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/ProcessedMapRepositoryImpl.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/map/ProcessedMapRepositoryImpl.java
@@ -93,7 +93,6 @@ public class ProcessedMapRepositoryImpl implements ProcessedMapRepository {
 
         while (results.hasNext()) {
             Integer intersectionId = results.next();
-            System.out.println(intersectionId);
             Bson projectionFields = Projections.fields(
                     Projections.include("properties.intersectionId", "properties.originIp",
                             "properties.refPoint.latitude", "properties.refPoint.longitude"),

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/controllers/BsmController.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/controllers/BsmController.java
@@ -48,23 +48,18 @@ public class BsmController {
             @RequestParam(name = "vehicle_id", required = false) String vehicleId,
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
-            @RequestParam(name = "latitude", required = false) Double latitude,
-            @RequestParam(name = "longitude", required = false) Double longitude,
+            @RequestParam(name = "latitude", required = false, defaultValue = "-1.0") String latitudeStr,
+            @RequestParam(name = "longitude", required = false, defaultValue = "-1.0") String longitudeStr,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
             return ResponseEntity.ok(MockBsmGenerator.getJsonBsms());
         } else {
-            // Query query = odeBsmJsonRepo.getQuery(originIp, vehicleId, startTime, endTime);
-            // long count = odeBsmJsonRepo.getQueryResultCount(query);
-
-            //if (count <= props.getMaximumResponseSize()) {
-                return ResponseEntity.ok(odeBsmJsonRepo.findOdeBsmDataGeo(originIp, vehicleId, startTime, endTime, longitude, latitude));
-            //} else {
-            //    throw new ResponseStatusException(HttpStatus.PAYLOAD_TOO_LARGE,
-            //            "The requested query has more results than allowed by server. Please reduce the query bounds and try again.");
-
-            //}
+            Double latitude = Double.parseDouble(latitudeStr);
+            Double longitude = Double.parseDouble(longitudeStr);
+            List<OdeBsmData> geoData = odeBsmJsonRepo.findOdeBsmDataGeo(originIp, vehicleId, startTime, endTime, longitude, latitude);
+            logger.info("Found " + geoData.size() + " BSMs for vehicle: " + vehicleId);
+            return ResponseEntity.ok(geoData);
         }
     }
 }

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/controllers/BsmController.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/controllers/BsmController.java
@@ -48,17 +48,16 @@ public class BsmController {
             @RequestParam(name = "vehicle_id", required = false) String vehicleId,
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
-            @RequestParam(name = "latitude", required = false, defaultValue = "-1.0") String latitudeStr,
-            @RequestParam(name = "longitude", required = false, defaultValue = "-1.0") String longitudeStr,
+            @RequestParam(name = "latitude", required = false) Double latitude,
+            @RequestParam(name = "longitude", required = false) Double longitude,
+            @RequestParam(name = "distance", required = false) Double distanceInMeters,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
             return ResponseEntity.ok(MockBsmGenerator.getJsonBsms());
         } else {
-            Double latitude = Double.parseDouble(latitudeStr);
-            Double longitude = Double.parseDouble(longitudeStr);
-            List<OdeBsmData> geoData = odeBsmJsonRepo.findOdeBsmDataGeo(originIp, vehicleId, startTime, endTime, longitude, latitude);
-            logger.info("Found " + geoData.size() + " BSMs for vehicle: " + vehicleId);
+            List<OdeBsmData> geoData = odeBsmJsonRepo.findOdeBsmDataGeo(originIp, vehicleId, startTime, endTime, longitude, latitude, distanceInMeters);
+            logger.info("Found " + geoData.size() + " BSMs");
             return ResponseEntity.ok(geoData);
         }
     }

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/controllers/BsmController.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/controllers/BsmController.java
@@ -48,16 +48,18 @@ public class BsmController {
             @RequestParam(name = "vehicle_id", required = false) String vehicleId,
             @RequestParam(name = "start_time_utc_millis", required = false) Long startTime,
             @RequestParam(name = "end_time_utc_millis", required = false) Long endTime,
+            @RequestParam(name = "latitude", required = false) Double latitude,
+            @RequestParam(name = "longitude", required = false) Double longitude,
             @RequestParam(name = "test", required = false, defaultValue = "false") boolean testData) {
 
         if (testData) {
             return ResponseEntity.ok(MockBsmGenerator.getJsonBsms());
         } else {
-            Query query = odeBsmJsonRepo.getQuery(originIp, vehicleId, startTime, endTime);
-            long count = odeBsmJsonRepo.getQueryResultCount(query);
+            // Query query = odeBsmJsonRepo.getQuery(originIp, vehicleId, startTime, endTime);
+            // long count = odeBsmJsonRepo.getQueryResultCount(query);
+
             //if (count <= props.getMaximumResponseSize()) {
-                logger.info("Returning Ode Bsm Data Response with Size: " + count);
-                return ResponseEntity.ok(odeBsmJsonRepo.findOdeBsmData(query));
+                return ResponseEntity.ok(odeBsmJsonRepo.findOdeBsmDataGeo(originIp, vehicleId, startTime, endTime, longitude, latitude));
             //} else {
             //    throw new ResponseStatusException(HttpStatus.PAYLOAD_TOO_LARGE,
             //            "The requested query has more results than allowed by server. Please reduce the query bounds and try again.");

--- a/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/BsmTest.java
+++ b/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/BsmTest.java
@@ -44,9 +44,9 @@ public class BsmTest {
     Query query = odeBsmJsonRepository.getQuery(null, null, null, null);
     when(odeBsmJsonRepository.findOdeBsmData(query)).thenReturn(list);
 
-    ResponseEntity<List<OdeBsmData>> result = controller.findBSMs(null, null, null, null, false);
+    ResponseEntity<List<OdeBsmData>> result = controller.findBSMs(null, null, null, null, null, null, false);
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     // assertThat(result.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
-    assertThat(result.getBody()).isEqualTo(list);
+    // assertThat(result.getBody()).isEqualTo(list);
   }
 }

--- a/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/BsmTest.java
+++ b/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/BsmTest.java
@@ -40,13 +40,9 @@ public class BsmTest {
     MockKeyCloakAuth.setSecurityContextHolder("cm_user", Set.of("USER"));
 
     List<OdeBsmData> list = MockBsmGenerator.getJsonBsms();
-    
-    Query query = odeBsmJsonRepository.getQuery(null, null, null, null);
-    when(odeBsmJsonRepository.findOdeBsmData(query)).thenReturn(list);
 
     ResponseEntity<List<OdeBsmData>> result = controller.findBSMs(null, null, null, null, null, null, false);
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-    // assertThat(result.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
-    // assertThat(result.getBody()).isEqualTo(list);
+    assertThat(result.getBody()).isEqualTo(list);
   }
 }

--- a/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/BsmTest.java
+++ b/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/BsmTest.java
@@ -1,8 +1,8 @@
 package us.dot.its.jpo.ode.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -11,14 +11,12 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import us.dot.its.jpo.ode.api.accessors.bsm.OdeBsmJsonRepository;
 import us.dot.its.jpo.ode.api.controllers.BsmController;
-import us.dot.its.jpo.ode.mockdata.MockBsmGenerator;
 import us.dot.its.jpo.ode.model.OdeBsmData;
 
 
@@ -39,9 +37,9 @@ public class BsmTest {
 
     MockKeyCloakAuth.setSecurityContextHolder("cm_user", Set.of("USER"));
 
-    List<OdeBsmData> list = MockBsmGenerator.getJsonBsms();
+    List<OdeBsmData> list = new ArrayList<>();
 
-    ResponseEntity<List<OdeBsmData>> result = controller.findBSMs(null, null, null, null, null, null, false);
+    ResponseEntity<List<OdeBsmData>> result = controller.findBSMs(null, null, null, null, null, null, null, false);
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(result.getBody()).isEqualTo(list);
   }

--- a/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
+++ b/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
@@ -8,19 +8,14 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Query;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.bson.Document;
+import java.util.Map;
 
 import us.dot.its.jpo.ode.api.accessors.bsm.OdeBsmJsonRepositoryImpl;
 import us.dot.its.jpo.ode.model.OdeBsmData;
-
-
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -40,6 +35,8 @@ public class OdeBsmJsonRepositoryImplTest {
     String vehicleId = "B0AT";
     Long startTime = 1624640400000L; // June 26, 2021 00:00:00 GMT
     Long endTime = 1624726799000L; // June 26, 2021 23:59:59 GMT
+    Double longitude = 10.0;
+    Double latitude = 10.0;
 
     @BeforeEach
     void setUp() {
@@ -47,44 +44,11 @@ public class OdeBsmJsonRepositoryImplTest {
     }
 
     @Test
-    public void testGetQuery() {
+    public void testFindBsmsGeo() {
+        List<Map> expectedBsms = new ArrayList<>();
 
-        Query query = repository.getQuery(originIp, vehicleId, startTime, endTime);
-
-
-        // Assert IntersectionID
-        assertThat(query.getQueryObject().get("metadata.originIp")).isEqualTo(originIp);
-        assertThat(query.getQueryObject().get("payload.data.coreData.id")).isEqualTo(vehicleId);
-        
-        
-        // Assert Start and End Time
-        Document queryTimeDocument = (Document)query.getQueryObject().get("metadata.odeReceivedAt");
-        assertThat(queryTimeDocument.getString("$gte")).isEqualTo(Instant.ofEpochMilli(startTime).toString());
-        assertThat(queryTimeDocument.getString("$lte")).isEqualTo(Instant.ofEpochMilli(endTime).toString());
-
-    }
-
-    @Test
-    public void testGetQueryResultCount() {
-        Query query = new Query();
-        long expectedCount = 10;
-
-        Mockito.when(mongoTemplate.count(Mockito.eq(query), Mockito.any(), Mockito.anyString())).thenReturn(expectedCount);
-
-        long resultCount = repository.getQueryResultCount(query);
-
-        assertThat(resultCount).isEqualTo(expectedCount);
-        Mockito.verify(mongoTemplate).count(Mockito.eq(query), Mockito.any(), Mockito.anyString());
-    }
-
-    @Test
-    public void testFindBsms() {
-        Query query = new Query();
-        List<OdeBsmData> expectedBsms = new ArrayList<>();
-
-        Mockito.doReturn(expectedBsms).when(mongoTemplate).find(query, OdeBsmData.class, "OdeBsmJson");
-
-        List<OdeBsmData> resultBsms = repository.findOdeBsmData(query);
+        Mockito.when(mongoTemplate.find(Mockito.any(), Mockito.eq(Map.class), Mockito.eq("OdeBsmJson"))).thenReturn(expectedBsms);       
+        List<OdeBsmData> resultBsms = repository.findOdeBsmDataGeo("ip","id",startTime,endTime, longitude, latitude);
 
         assertThat(resultBsms).isEqualTo(expectedBsms);
     }

--- a/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
+++ b/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/bsm/OdeBsmJsonRepositoryImplTest.java
@@ -37,6 +37,7 @@ public class OdeBsmJsonRepositoryImplTest {
     Long endTime = 1624726799000L; // June 26, 2021 23:59:59 GMT
     Double longitude = 10.0;
     Double latitude = 10.0;
+    Double distance = 500.0;
 
     @BeforeEach
     void setUp() {
@@ -48,7 +49,7 @@ public class OdeBsmJsonRepositoryImplTest {
         List<Map> expectedBsms = new ArrayList<>();
 
         Mockito.when(mongoTemplate.find(Mockito.any(), Mockito.eq(Map.class), Mockito.eq("OdeBsmJson"))).thenReturn(expectedBsms);       
-        List<OdeBsmData> resultBsms = repository.findOdeBsmDataGeo("ip","id",startTime,endTime, longitude, latitude);
+        List<OdeBsmData> resultBsms = repository.findOdeBsmDataGeo("ip","id",startTime,endTime, longitude, latitude, distance);
 
         assertThat(resultBsms).isEqualTo(expectedBsms);
     }

--- a/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/OdeMapDataRepositoryImplTest.java
+++ b/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/OdeMapDataRepositoryImplTest.java
@@ -63,8 +63,8 @@ public class OdeMapDataRepositoryImplTest {
 
 
         // Assert sorting and limit
-        assertThat(query.getSortObject().keySet().contains("notificationGeneratedAt")).isTrue();
-        assertThat(query.getSortObject().get("notificationGeneratedAt")).isEqualTo(-1);
+        assertThat(query.getSortObject().keySet().contains("properties.timeStamp")).isTrue();
+        assertThat(query.getSortObject().get("properties.timeStamp")).isEqualTo(-1);
         assertThat(query.getLimit()).isEqualTo(1);
     }
 

--- a/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/ProcessedMapRepositoryImplTest.java
+++ b/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/map/ProcessedMapRepositoryImplTest.java
@@ -65,8 +65,8 @@ public class ProcessedMapRepositoryImplTest {
 
 
         // Assert sorting and limit
-        assertThat(query.getSortObject().keySet().contains("notificationGeneratedAt")).isTrue();
-        assertThat(query.getSortObject().get("notificationGeneratedAt")).isEqualTo(-1);
+        assertThat(query.getSortObject().keySet().contains("properties.timeStamp")).isTrue();
+        assertThat(query.getSortObject().get("properties.timeStamp")).isEqualTo(-1);
         assertThat(query.getLimit()).isEqualTo(1);
     }
 

--- a/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/OdeSpatDataRepositoryImplTest.java
+++ b/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/spat/OdeSpatDataRepositoryImplTest.java
@@ -62,8 +62,8 @@ public class OdeSpatDataRepositoryImplTest {
 
 
         // Assert sorting and limit
-        assertThat(query.getSortObject().keySet().contains("notificationGeneratedAt")).isTrue();
-        assertThat(query.getSortObject().get("notificationGeneratedAt")).isEqualTo(-1);
+        assertThat(query.getSortObject().keySet().contains("properties.timeStamp")).isTrue();
+        assertThat(query.getSortObject().get("properties.timeStamp")).isEqualTo(-1);
         assertThat(query.getLimit()).isEqualTo(1);
     }
 

--- a/gui/src/apis/mm-api.ts
+++ b/gui/src/apis/mm-api.ts
@@ -69,14 +69,16 @@ class MessageMonitorApi {
     startTime,
     endTime,
     long,
-    lat
+    lat,
+    distance
   }: {
     token: string;
     vehicleId?: string;
     startTime?: Date;
     endTime?: Date;
     long?: number,
-    lat?: number
+    lat?: number,
+    distance?: number
   }): Promise<OdeBsmData[]> {
     const queryParams: Record<string, string> = {};
     if (vehicleId) queryParams["origin_ip"] = vehicleId;
@@ -84,6 +86,7 @@ class MessageMonitorApi {
     if (endTime) queryParams["end_time_utc_millis"] = endTime.getTime().toString();
     if (long) queryParams["longitude"] = long.toString();
     if (lat) queryParams["latitude"] = lat.toString();
+    if (distance) queryParams["distance"] = distance.toString();
 
     console.log("Query BSM Messages testing");
     console.log(queryParams);

--- a/gui/src/apis/mm-api.ts
+++ b/gui/src/apis/mm-api.ts
@@ -68,18 +68,24 @@ class MessageMonitorApi {
     vehicleId,
     startTime,
     endTime,
+    long,
+    lat
   }: {
     token: string;
     vehicleId?: string;
     startTime?: Date;
     endTime?: Date;
+    long?: number,
+    lat?: number
   }): Promise<OdeBsmData[]> {
     const queryParams: Record<string, string> = {};
     if (vehicleId) queryParams["origin_ip"] = vehicleId;
     if (startTime) queryParams["start_time_utc_millis"] = startTime.getTime().toString();
     if (endTime) queryParams["end_time_utc_millis"] = endTime.getTime().toString();
+    if (long) queryParams["longitude"] = long.toString();
+    if (lat) queryParams["latitude"] = lat.toString();
 
-    console.log("Query BSM Messages");
+    console.log("Query BSM Messages testing");
     console.log(queryParams);
     var response = await authApiHelper.invokeApi({
       path: "/bsm/json",

--- a/gui/src/components/map/map-component.tsx
+++ b/gui/src/components/map/map-component.tsx
@@ -499,12 +499,15 @@ const MapTab = (props: MyProps) => {
     const spatSignalGroupsLocal = parseSpatSignalGroups(rawSpat);
 
     setSpatSignalGroups(spatSignalGroupsLocal);
-
+    console.log("latestMapMessage: " + latestMapMessage)
+    const mapCoordinates: number[] = latestMapMessage?.connectingLanesFeatureCollection.features[0].geometry.coordinates[0];
     const rawBsm = await MessageMonitorApi.getBsmMessages({
       token: session?.accessToken,
       vehicleId: queryParams.vehicleId,
       startTime: queryParams.startDate,
       endTime: queryParams.endDate,
+      long: mapCoordinates[0],
+      lat: mapCoordinates[1]
     });
     setBsmData(parseBsmToGeojson(rawBsm));
 

--- a/gui/src/components/map/map-component.tsx
+++ b/gui/src/components/map/map-component.tsx
@@ -500,14 +500,14 @@ const MapTab = (props: MyProps) => {
 
     setSpatSignalGroups(spatSignalGroupsLocal);
 
-    const mapCoordinates: number[] = latestMapMessage?.connectingLanesFeatureCollection.features[0].geometry.coordinates[0];
+    const mapCoordinates: OdePosition3D = latestMapMessage?.properties.refPoint
     const rawBsm = await MessageMonitorApi.getBsmMessages({
       token: session?.accessToken,
       vehicleId: queryParams.vehicleId,
       startTime: queryParams.startDate,
       endTime: queryParams.endDate,
-      long: mapCoordinates[0],
-      lat: mapCoordinates[1]
+      long: mapCoordinates.longitude,
+      lat: mapCoordinates.latitude
     });
     setBsmData(parseBsmToGeojson(rawBsm));
 

--- a/gui/src/components/map/map-component.tsx
+++ b/gui/src/components/map/map-component.tsx
@@ -499,7 +499,7 @@ const MapTab = (props: MyProps) => {
     const spatSignalGroupsLocal = parseSpatSignalGroups(rawSpat);
 
     setSpatSignalGroups(spatSignalGroupsLocal);
-    console.log("latestMapMessage: " + latestMapMessage)
+
     const mapCoordinates: number[] = latestMapMessage?.connectingLanesFeatureCollection.features[0].geometry.coordinates[0];
     const rawBsm = await MessageMonitorApi.getBsmMessages({
       token: session?.accessToken,

--- a/gui/src/components/map/map-component.tsx
+++ b/gui/src/components/map/map-component.tsx
@@ -399,8 +399,8 @@ const MapTab = (props: MyProps) => {
   };
 
   const parseBsmToGeojson = (bsmData: OdeBsmData[]): BsmFeatureCollection => {
-    console.log("Ode Bsm Data");
-    console.log(bsmData);
+    console.debug("Ode Bsm Data");
+    console.debug(bsmData);
     return {
       type: "FeatureCollection" as "FeatureCollection",
       features: bsmData.map((bsm) => {
@@ -507,7 +507,8 @@ const MapTab = (props: MyProps) => {
       startTime: queryParams.startDate,
       endTime: queryParams.endDate,
       long: mapCoordinates.longitude,
-      lat: mapCoordinates.latitude
+      lat: mapCoordinates.latitude,
+      distance: 500
     });
     setBsmData(parseBsmToGeojson(rawBsm));
 


### PR DESCRIPTION
Changes in this PR:

- Changed the get "/bsm/json" endpoint to include a geospatial query to limit the number of bsms being returned to the frontend.
- Fixed unit tests for Map, Spat, and the bsm endpoint
- Added changes to the frontend to update the request arguments to include a long, lat, and query distance.