### PR TITLE
Improve readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,20 @@ Alternatively, clone the repository first, then import submodules second
 git submodule update --init --recursive
 ```
 
-### 2. Clone and Run jpo-ode, jpo-geojsonconverter, and jpo-conflictmonitor docker images
+### 2. Build and Run jpo-ode, jpo-geojsonconverter, and jpo-conflictmonitor docker images
 
-Run ODE, then GeoJSONConverter, then ConflictMonitor. Please see the individual repositories for each for information on how to deploy each of these.
+Run [ODE](https://github.com/usdot-jpo-ode/jpo-ode#step-2---build-and-run-the-application), then [GeoJSONConverter](https://github.com/usdot-jpo-ode/jpo-geojsonconverter#step-2---build-and-run-jpo-ode-application), then [ConflictMonitor](https://github.com/usdot-jpo-ode/jpo-conflictmonitor#step-2---build-and-run-jpo-ode-application). Each can be built and run by navigating to their respective directories that contain a pom.xml, then running:
+
+```
+mvn install
+```
+
+or to skip the tests:
+
+```
+mvn install -DskipTests
+```
+
 
 ### 3. Configure Conflict Visualizer API
 


### PR DESCRIPTION
This set of 3 matching pull requests aim to clarify a few points in the Readme installation instructions that slowed me down when I was installing the environment for the first time. I don't necessarily have a big-picture in mind around which components might or might not be designed to run independently, so please correct me if any of my additions are missing important context.