### PR TITLE
Add daily timeline

### DIFF
--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/ConflictApiApplication.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/ConflictApiApplication.java
@@ -3,12 +3,8 @@ package us.dot.its.jpo.ode.api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
-import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableWebMvc

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/BsmEvent/BsmEventRepositoryImpl.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/BsmEvent/BsmEventRepositoryImpl.java
@@ -46,10 +46,10 @@ public class BsmEventRepositoryImpl implements BsmEventRepository {
             query.addCriteria(Criteria.where("intersectionID").is(intersectionID));
         }
 
-        if (startTime != null) {
+        if (startTime == null) {
             startTime = 0L;
         }
-        if (endTime != null) {
+        if (endTime == null) {
             endTime = Instant.now().toEpochMilli();
         }
 

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/BsmEvent/BsmEventRepositoryImpl.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/BsmEvent/BsmEventRepositoryImpl.java
@@ -1,8 +1,9 @@
 package us.dot.its.jpo.ode.api.accessors.events.BsmEvent;
 
 import java.time.Instant;
-import java.util.Date;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -10,7 +11,11 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import us.dot.its.jpo.conflictmonitor.monitor.models.bsm.BsmEvent;
+import us.dot.its.jpo.geojsonconverter.DateJsonMapper;
+
 import org.springframework.data.domain.Sort;
 
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -29,6 +34,8 @@ public class BsmEventRepositoryImpl implements BsmEventRepository {
 
     private String collectionName = "CmBsmEvents";
 
+    private ObjectMapper mapper = DateJsonMapper.getInstance();
+
     @Autowired
     ConflictMonitorApiProperties props;
 
@@ -38,23 +45,22 @@ public class BsmEventRepositoryImpl implements BsmEventRepository {
         if (intersectionID != null) {
             query.addCriteria(Criteria.where("intersectionID").is(intersectionID));
         }
-        Date startTimeDate = new Date(0);
-        Date endTimeDate = new Date();
 
         if (startTime != null) {
-            startTimeDate = new Date(startTime);
+            startTime = 0L;
         }
         if (endTime != null) {
-            endTimeDate = new Date(endTime);
+            endTime = Instant.now().toEpochMilli();
         }
 
-        query.addCriteria(Criteria.where("recordGeneratedAt").gte(startTimeDate).lte(endTimeDate));
+        query.addCriteria(Criteria.where("startingBsmTimestamp").gte(startTime).lte(endTime));
         if (latest) {
-            query.with(Sort.by(Sort.Direction.DESC, "recordGeneratedAt"));
+            query.with(Sort.by(Sort.Direction.DESC, "startingBsmTimestamp"));
             query.limit(1);
         }else{
             query.limit(props.getMaximumResponseSize());
         }
+        query.fields().exclude("recordGeneratedAt");
         return query;
     }
 
@@ -63,7 +69,17 @@ public class BsmEventRepositoryImpl implements BsmEventRepository {
     }
 
     public List<BsmEvent> find(Query query) {
-        return mongoTemplate.find(query, BsmEvent.class, collectionName);
+
+        List<Map> documents = mongoTemplate.find(query, Map.class, collectionName);
+        List<BsmEvent> convertedList = new ArrayList<>();
+
+        for(Map document : documents){
+            document.remove("_id");
+            BsmEvent event = mapper.convertValue(document, BsmEvent.class);
+            convertedList.add(event);
+        }
+
+        return convertedList;
     }
 
     @Override

--- a/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/BsmEventRepositoryImplTest.java
+++ b/api/jpo-conflictvisualizer-api/src/test/java/us/dot/its/jpo/ode/api/accessorTests/events/BsmEventRepositoryImplTest.java
@@ -56,15 +56,15 @@ public class BsmEventRepositoryImplTest {
         assertThat(query.getQueryObject().get("intersectionID")).isEqualTo(intersectionID);
         
         
-        // Assert Start and End Time
-        Document queryTimeDocument = (Document)query.getQueryObject().get("recordGeneratedAt");
-        assertThat(queryTimeDocument.getDate("$gte")).isEqualTo(new Date(startTime));
-        assertThat(queryTimeDocument.getDate("$lte")).isEqualTo(new Date(endTime));
+        // // Assert Start and End Time
+        Document queryTimeDocument = (Document)query.getQueryObject().get("startingBsmTimestamp");
+        assertThat(queryTimeDocument.getLong("$gte")).isEqualTo(startTime);
+        assertThat(queryTimeDocument.getLong("$lte")).isEqualTo(endTime);
 
 
-        // Assert sorting and limit
-        assertThat(query.getSortObject().keySet().contains("recordGeneratedAt")).isTrue();
-        assertThat(query.getSortObject().get("recordGeneratedAt")).isEqualTo(-1);
+        // // Assert sorting and limit
+        assertThat(query.getSortObject().keySet().contains("startingBsmTimestamp")).isTrue();
+        assertThat(query.getSortObject().get("startingBsmTimestamp")).isEqualTo(-1);
         assertThat(query.getLimit()).isEqualTo(1);
 
     }

--- a/gui/src/apis/events-api.ts
+++ b/gui/src/apis/events-api.ts
@@ -85,7 +85,7 @@ class EventsApi {
     startTime: Date,
     endTime: Date,
     { test = false }: { test?: boolean } = {}
-  ): Promise<MessageMonitor.Event[]> {
+  ): Promise<MessageMonitor.MinuteCount[]> {
     const queryParams = {
       intersection_id: intersectionId.toString(),
       start_time_utc_millis: startTime.getTime().toString(),
@@ -100,7 +100,7 @@ class EventsApi {
       queryParams: queryParams,
       failureMessage: `Failed to retrieve bsm events by minute`,
     });
-    return response ?? ([] as MessageMonitor.Event[]);
+    return response ?? ([] as MessageMonitor.MinuteCount[]);
   }
 }
 

--- a/gui/src/apis/events-api.ts
+++ b/gui/src/apis/events-api.ts
@@ -78,6 +78,30 @@ class EventsApi {
     }
     return events;
   }
+
+  async getBsmByMinuteEvents(
+    token: string,
+    intersectionId: number,
+    startTime: Date,
+    endTime: Date,
+    { test = false }: { test?: boolean } = {}
+  ): Promise<MessageMonitor.Event[]> {
+    const queryParams = {
+      intersection_id: intersectionId.toString(),
+      start_time_utc_millis: startTime.getTime().toString(),
+      end_time_utc_millis: endTime.getTime().toString(),
+      test: test.toString(),
+    };
+    // if (roadRegulatorId) queryParams["road_regulator_id"] = roadRegulatorId;
+
+    const response = await authApiHelper.invokeApi({
+      path: `/events/bsm_events_by_minute`,
+      token: token,
+      queryParams: queryParams,
+      failureMessage: `Failed to retrieve bsm events by minute`,
+    });
+    return response ?? ([] as MessageMonitor.Event[]);
+  }
 }
 
 export default new EventsApi();

--- a/gui/src/components/map/control-panel.tsx
+++ b/gui/src/components/map/control-panel.tsx
@@ -18,6 +18,7 @@ import ScrollBar from "react-perfect-scrollbar";
 import pauseIcon from '../../../public/pause.png';
 import playIcon from '../../../public/play.png';
 
+import { BarChart, XAxis, Bar, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 
 const Accordion = styled((props: AccordionProps) => <MuiAccordion disableGutters elevation={0} square {...props} />)(
   ({ theme }) => ({
@@ -92,6 +93,7 @@ interface ControlPanelProps {
     notification?: MessageMonitor.Notification;
     event?: MessageMonitor.Event;
     assessment?: Assessment;
+    bsmEventsByMinute?: MessageMonitor.Event[];
   };
 }
 
@@ -271,6 +273,70 @@ function ControlPanel(props: ControlPanelProps) {
     return num;
   };
 
+  const timelineTicks = [
+    120,
+    240,
+    360,
+    480,
+    600,
+    720,
+    840,
+    960,
+    1080,
+    1200,
+    1320
+  ];
+    const formatMinutesAfterMidnightTime = (minutes) => {
+      const hours = Math.floor(minutes / 60);
+      const mins = minutes % 60;
+      return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}`;
+    };
+    
+    const reformattedTimelineData = bsmByMinute().map(item => {
+      console.log("BSM Events: ", props.rawData?.bsmEventsByMinute);
+      const minutesAfterMidnight = Math.floor(item.msTime / 60 / 1000) % 1440;
+      return {
+      ...item,
+      minutesAfterMidnight,
+      timestamp: formatMinutesAfterMidnightTime(minutesAfterMidnight),
+      };
+    });
+
+  const TimelineTooltip = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="custom-tooltip" style={{ backgroundColor: '#fff', padding: '10px', border: '1px solid #ccc', position: 'relative', bottom: '15px' }}>
+          <p className="label" style={{ color: '#333' }}>{`Time: ${payload[0].payload.timestamp}`}</p>
+          <p className="intro" style={{ color: '#333' }}>{`Events: ${payload[0].payload.count}`}</p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const TimelineCursor = ({ x, y, width, height }) => (
+    <rect
+      x={(x+width/2)-6}
+      y={y-1}
+      width={12}
+      height={height+3}
+      fill="#10B981"
+      style={{ pointerEvents: 'none' }}
+    />
+  );
+
+  const TimelineAxisTick = ({ x, y, payload }) => {
+    const timeString = formatMinutesAfterMidnightTime(payload.value);
+
+    return (
+      <g transform={`translate(${x},${y})`}>
+        <text x={0} y={0} dy={0} textAnchor="middle">
+          {timeString}
+        </text>
+      </g>
+    );
+  };
+
   const openMessageData = (files: FileList | null) => {
     if (files == null) return;
     const file = files[0];
@@ -427,6 +493,23 @@ function ControlPanel(props: ControlPanelProps) {
                 ? "No Data"
                 : format(props.mapSpatTimes.spatTime * 1000, "MM/dd/yyyy HH:mm:ss")}
             </h4>
+            <ResponsiveContainer width="100%" height={50}>
+              <BarChart data={reformattedTimelineData} barGap={0} barCategoryGap={0} onClick={(data) => {
+                if(data !== null && data.activePayload !== undefined){
+                  setEventTime(dayjs(data.activePayload[0].payload.msTime));
+                }
+              }}>
+                <XAxis dataKey="minutesAfterMidnight" type="number" mirror domain={[0,1440]} tick={<TimelineAxisTick />} ticks={timelineTicks}/>
+                <Bar dataKey="count" fill="#D14343" barSize={10} minPointSize={10}>
+                </Bar>
+                <Tooltip
+                  cursor={<TimelineCursor />}
+                  content={({ active, payload, label }) => (
+                    <TimelineTooltip active={active} payload={payload} label={label}/>
+                  )}
+                />
+              </BarChart>
+            </ResponsiveContainer>
             <Button
               sx={{ m: 1 }}
               variant="contained"

--- a/gui/src/components/map/control-panel.tsx
+++ b/gui/src/components/map/control-panel.tsx
@@ -363,7 +363,7 @@ function ControlPanel(props: ControlPanelProps) {
       y={y-1}
       width={12}
       height={height+3}
-      fill="#10B981"
+      fill={(reformattedTimelineData != null && reformattedTimelineData.length > 0)? "#10B981" : "transparent"}
       style={{ pointerEvents: 'none' }}
     />
   );
@@ -538,7 +538,7 @@ function ControlPanel(props: ControlPanelProps) {
             </h4>
             <ResponsiveContainer width="100%" height={50}>
               <BarChart data={reformattedTimelineData} barGap={0} barCategoryGap={0} onClick={(data) => {
-                if(data !== null && data.activePayload !== undefined){
+                if(data !== null && data.activePayload !== undefined && data.activePayload !== null){
                   setEventTime(dayjs(data.activePayload[0].payload.msTime));
                 }
               }}>

--- a/gui/src/components/map/control-panel.tsx
+++ b/gui/src/components/map/control-panel.tsx
@@ -347,7 +347,7 @@ function ControlPanel(props: ControlPanelProps) {
     const timeString = formatMinutesAfterMidnightTime(payload?.value);
     return (
       <g transform={`translate(${x},${y})`}>
-        <text x={0} y={0} dy={0} textAnchor="middle">
+        <text x={0} y={0} dy={10} textAnchor="middle">
           {timeString}
         </text>
       </g>
@@ -510,13 +510,17 @@ function ControlPanel(props: ControlPanelProps) {
                 ? "No Data"
                 : format(props.mapSpatTimes.spatTime * 1000, "MM/dd/yyyy HH:mm:ss")}
             </h4>
-            <ResponsiveContainer width="100%" height={50}>
+            <h4>
+              Activity Chart for {format(props.sliderTimeValue.start, "MM/dd/yyyy")}:
+            </h4>
+
+            <ResponsiveContainer width="100%" height={80}>
               <BarChart data={reformattedTimelineData} barGap={0} barCategoryGap={0} onClick={(data) => {
                 if(data !== null && data.activePayload !== undefined && data.activePayload !== null){
                   setEventTime(dayjs(data.activePayload[0].payload.minute));
                 }
               }}>
-                <XAxis dataKey="minutesAfterMidnight" type="number" mirror domain={[0,1440]} tick={<TimelineAxisTick />} ticks={timelineTicks}/>
+                <XAxis dataKey="minutesAfterMidnight" type="number" domain={[0,1440]} tick={<TimelineAxisTick />} ticks={timelineTicks}/>
                 <Bar dataKey="count" fill="#D14343" barSize={10} minPointSize={10}>
                 </Bar>
                 <Tooltip

--- a/gui/src/components/map/map-component.tsx
+++ b/gui/src/components/map/map-component.tsx
@@ -24,6 +24,7 @@ import * as turf from "@turf/turf";
 
 import { CompatClient, IMessage, Stomp } from "@stomp/stompjs";
 import { set } from "date-fns";
+import { BarChart, XAxis, Bar, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 
 const { publicRuntimeConfig } = getConfig();
 
@@ -366,6 +367,7 @@ const MapTab = (props: MyProps) => {
   const [filteredSurroundingNotifications, setFilteredSurroundingNotifications] = useState<
     MessageMonitor.Notification[]
   >([]);
+  const [BsmEventsByMinute, setBsmEventsByMinute] = useState<MessageMonitor.Event[]>([]);
   //   const mapRef = useRef<mapboxgl.Map>();
   const [viewState, setViewState] = useState({
     latitude: 39.587905,
@@ -385,6 +387,7 @@ const MapTab = (props: MyProps) => {
     notification?: MessageMonitor.Notification;
     event?: MessageMonitor.Event;
     assessment?: Assessment;
+    bsmEventsByMinute?: MessageMonitor.Event[];
   }>({});
   const [mapSpatTimes, setMapSpatTimes] = useState({ mapTime: 0, spatTime: 0 });
   const [sigGroupLabelsVisible, setSigGroupLabelsVisible] = useState<boolean>(false);
@@ -806,6 +809,17 @@ const MapTab = (props: MyProps) => {
       });
       surroundingEventsPromise.then((events) => setSurroundingEvents(events));
 
+      // ######################### BSM Events By Minute #########################
+      const bsmEventsByMinutePromise = EventsApi.getBsmByMinuteEvents(
+        session?.accessToken,
+        queryParams.intersectionId,
+        queryParams.startDate,
+        queryParams.endDate,
+        { test: true }
+      );
+      bsmEventsByMinutePromise.then((events) => setBsmEventsByMinute(events));
+      setRawData((prevValue) => ({ ...prevValue, bsmEventsByMinute: BsmEventsByMinute }));
+
       // ######################### Surrounding Notifications #########################
       const surroundingNotificationsPromise = NotificationApi.getAllNotifications({
         token: session?.accessToken,
@@ -936,6 +950,7 @@ const MapTab = (props: MyProps) => {
     } else if (props.sourceDataType == "assessment") {
       rawData["assessment"] = props.sourceData as Assessment;
     }
+    rawData["bsmEventsByMinute"] = BsmEventsByMinute;
     setRawData(rawData);
 
     // ######################### Set Slider Position #########################

--- a/gui/src/components/map/map-component.tsx
+++ b/gui/src/components/map/map-component.tsx
@@ -367,7 +367,7 @@ const MapTab = (props: MyProps) => {
   const [filteredSurroundingNotifications, setFilteredSurroundingNotifications] = useState<
     MessageMonitor.Notification[]
   >([]);
-  const [BsmEventsByMinute, setBsmEventsByMinute] = useState<MessageMonitor.Event[]>([]);
+  const [BsmEventsByMinute, setBsmEventsByMinute] = useState<MessageMonitor.MinuteCount[]>([]);
   //   const mapRef = useRef<mapboxgl.Map>();
   const [viewState, setViewState] = useState({
     latitude: 39.587905,
@@ -387,7 +387,7 @@ const MapTab = (props: MyProps) => {
     notification?: MessageMonitor.Notification;
     event?: MessageMonitor.Event;
     assessment?: Assessment;
-    bsmEventsByMinute?: MessageMonitor.Event[];
+    bsmEventsByMinute?: MessageMonitor.MinuteCount[];
   }>({});
   const [mapSpatTimes, setMapSpatTimes] = useState({ mapTime: 0, spatTime: 0 });
   const [sigGroupLabelsVisible, setSigGroupLabelsVisible] = useState<boolean>(false);
@@ -822,8 +822,6 @@ const MapTab = (props: MyProps) => {
         dayEnd,
         { test: true }
       );
-      console.log("Start and End Dates", queryParams.startDate, queryParams.endDate);
-      console.log("dayStart and dayEnd", dayStart, dayEnd);
       bsmEventsByMinutePromise.then((events) => setBsmEventsByMinute(events));
       setRawData((prevValue) => ({ ...prevValue, bsmEventsByMinute: BsmEventsByMinute }));
 

--- a/gui/src/components/map/map-component.tsx
+++ b/gui/src/components/map/map-component.tsx
@@ -810,13 +810,22 @@ const MapTab = (props: MyProps) => {
       surroundingEventsPromise.then((events) => setSurroundingEvents(events));
 
       // ######################### BSM Events By Minute #########################
+      const dayStart = new Date(queryParams.startDate);
+      dayStart.setHours(0, 0, 0, 0);
+      const dayEnd = new Date(queryParams.startDate);
+      dayEnd.setHours(23, 59, 59, 0);
+
       const bsmEventsByMinutePromise = EventsApi.getBsmByMinuteEvents(
         session?.accessToken,
         queryParams.intersectionId,
         queryParams.startDate,
         queryParams.endDate,
+        dayStart,
+        dayEnd,
         { test: true }
       );
+      console.log("Start and End Dates", queryParams.startDate, queryParams.endDate);
+      console.log("dayStart and dayEnd", dayStart, dayEnd);
       bsmEventsByMinutePromise.then((events) => setBsmEventsByMinute(events));
       setRawData((prevValue) => ({ ...prevValue, bsmEventsByMinute: BsmEventsByMinute }));
 

--- a/gui/src/components/map/map-component.tsx
+++ b/gui/src/components/map/map-component.tsx
@@ -818,8 +818,6 @@ const MapTab = (props: MyProps) => {
       const bsmEventsByMinutePromise = EventsApi.getBsmByMinuteEvents(
         session?.accessToken,
         queryParams.intersectionId,
-        queryParams.startDate,
-        queryParams.endDate,
         dayStart,
         dayEnd,
         { test: true }

--- a/gui/src/components/map/map-component.tsx
+++ b/gui/src/components/map/map-component.tsx
@@ -820,7 +820,7 @@ const MapTab = (props: MyProps) => {
         queryParams.intersectionId,
         dayStart,
         dayEnd,
-        { test: true }
+        { test: false }
       );
       bsmEventsByMinutePromise.then((events) => setBsmEventsByMinute(events));
       setRawData((prevValue) => ({ ...prevValue, bsmEventsByMinute: BsmEventsByMinute }));

--- a/gui/src/models/jpo-conflictmonitor/events/MinuteCount.d.ts
+++ b/gui/src/models/jpo-conflictmonitor/events/MinuteCount.d.ts
@@ -1,0 +1,6 @@
+declare namespace MessageMonitor {
+type MinuteCount = {
+  minute: number
+  count: number
+}
+}


### PR DESCRIPTION
These changes implement a timeline showing the frequency and times of all BSM activity for the selected day at a glance, allowing users to quickly select a relevant time window to view BSM activity. 

![image](https://github.com/usdot-jpo-ode/jpo-conflictvisualizer/assets/157423531/8f7f601c-89b7-43bc-b2b0-ecc6b1a9a799)
