### PR TITLE
Load SPATs before BSMs are fully loaded

### DIFF
--- a/gui/src/components/map/map-component.tsx
+++ b/gui/src/components/map/map-component.tsx
@@ -885,6 +885,11 @@ const MapTab = (props: MyProps) => {
     const spatSignalGroupsLocal = parseSpatSignalGroups(rawSpat);
 
     setSpatSignalGroups(spatSignalGroupsLocal);
+    
+    renderEntireMap(rawMap, rawSpat, {
+      "type": "FeatureCollection",
+      features: [],
+    });
 
     // ######################### BSMs #########################
     if (!importedMessageData) {


### PR DESCRIPTION
Loading SPAT messages before BSM messages are fully loaded. This is a very small change. 