### PR TITLE
Message progression events

### DIFF
--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/BsmMessageCountProgressionEventRepository/BsmMessageCountProgressionEventRepository.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/BsmMessageCountProgressionEventRepository/BsmMessageCountProgressionEventRepository.java
@@ -1,0 +1,20 @@
+package us.dot.its.jpo.ode.api.accessors.events.BsmMessageCountProgressionEventRepository;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.core.query.Query;
+import us.dot.its.jpo.ode.api.models.IDCount;
+import us.dot.its.jpo.ode.api.models.DataLoader;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.BsmMessageCountProgressionEvent;
+
+public interface BsmMessageCountProgressionEventRepository extends DataLoader<BsmMessageCountProgressionEvent>{
+    Query getQuery(Integer intersectionID, Long startTime, Long endTime, boolean latest);
+
+    long getQueryResultCount(Query query);
+
+    long getQueryFullCount(Query query);
+    
+    List<BsmMessageCountProgressionEvent> find(Query query);
+
+    List<IDCount> getBsmBroadcastRateEventsByDay(int intersectionID, Long startTime, Long endTime);
+}

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/BsmMessageCountProgressionEventRepository/BsmMessageCountProgressionRepositoryImpl.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/BsmMessageCountProgressionEventRepository/BsmMessageCountProgressionRepositoryImpl.java
@@ -1,0 +1,113 @@
+package us.dot.its.jpo.ode.api.accessors.events.BsmMessageCountProgressionEventRepository;
+
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Component;
+
+
+import org.springframework.data.domain.Sort;
+
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.DateOperators;
+
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.BsmMessageCountProgressionEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
+import us.dot.its.jpo.ode.api.models.IDCount;
+
+@Component
+public class BsmMessageCountProgressionRepositoryImpl implements BsmMessageCountProgressionEventRepository {
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    ConflictMonitorApiProperties props;
+
+    private String collectionName = "CmBsmMessageCountProgressionEvents";
+
+    public Query getQuery(Integer intersectionID, Long startTime, Long endTime, boolean latest) {
+        Query query = new Query();
+
+        if (intersectionID != null) {
+            query.addCriteria(Criteria.where("intersectionID").is(intersectionID));
+        }
+        Date startTimeDate = new Date(0);
+        Date endTimeDate = new Date();
+
+        if (startTime != null) {
+            startTimeDate = new Date(startTime);
+        }
+        if (endTime != null) {
+            endTimeDate = new Date(endTime);
+        }
+
+        query.addCriteria(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate));
+        if (latest) {
+            query.with(Sort.by(Sort.Direction.DESC, "eventGeneratedAt"));
+            query.limit(1);
+        }else{
+            query.limit(props.getMaximumResponseSize());
+        }
+        return query;
+    }
+
+    public long getQueryResultCount(Query query) {
+        return mongoTemplate.count(query, BsmMessageCountProgressionEvent.class, collectionName);
+    }
+
+    public long getQueryFullCount(Query query){
+        int limit = query.getLimit();
+        query.limit(-1);
+        long count = mongoTemplate.count(query, BsmMessageCountProgressionEvent.class, collectionName);
+        query.limit(limit);
+        return count;
+    }
+
+    public List<BsmMessageCountProgressionEvent> find(Query query) {
+        return mongoTemplate.find(query, BsmMessageCountProgressionEvent.class, collectionName);
+    }
+
+    public List<IDCount> getBsmMessageCountProgressionEventsByDay(int intersectionID, Long startTime, Long endTime){
+        Date startTimeDate = new Date(0);
+        Date endTimeDate = new Date();
+
+        if (startTime != null) {
+            startTimeDate = new Date(startTime);
+        }
+        if (endTime != null) {
+            endTimeDate = new Date(endTime);
+        }
+
+        Aggregation aggregation = Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
+            Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+            Aggregation.project()
+                .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("%Y-%m-%d")).as("dateStr"),
+            Aggregation.group("dateStr").count().as("count")
+        );
+
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        List<IDCount> results = result.getMappedResults();
+
+        return results;
+    }
+
+    @Override
+    public void add(BsmMessageCountProgressionEvent item) {
+        mongoTemplate.save(item, collectionName);
+    }
+
+    @Override
+    public List<IDCount> getBsmBroadcastRateEventsByDay(int intersectionID, Long startTime, Long endTime) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getBsmBroadcastRateEventsByDay'");
+    }
+
+
+}

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/MapMessageCountProgressionEventRepository/MapMessageCountProgressionEventRepository.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/MapMessageCountProgressionEventRepository/MapMessageCountProgressionEventRepository.java
@@ -1,0 +1,20 @@
+package us.dot.its.jpo.ode.api.accessors.events.MapMessageCountProgressionEventRepository;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.core.query.Query;
+import us.dot.its.jpo.ode.api.models.IDCount;
+import us.dot.its.jpo.ode.api.models.DataLoader;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.MapMessageCountProgressionEvent;
+
+public interface MapMessageCountProgressionEventRepository extends DataLoader<MapMessageCountProgressionEvent>{
+    Query getQuery(Integer intersectionID, Long startTime, Long endTime, boolean latest);
+
+    long getQueryResultCount(Query query);
+
+    long getQueryFullCount(Query query);
+    
+    List<MapMessageCountProgressionEvent> find(Query query);
+
+    List<IDCount> getMapBroadcastRateEventsByDay(int intersectionID, Long startTime, Long endTime);
+}

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/MapMessageCountProgressionEventRepository/MapMessageCountProgressionRepositoryImpl.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/MapMessageCountProgressionEventRepository/MapMessageCountProgressionRepositoryImpl.java
@@ -1,0 +1,114 @@
+package us.dot.its.jpo.ode.api.accessors.events.MapMessageCountProgressionEventRepository;
+
+
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Component;
+
+
+import org.springframework.data.domain.Sort;
+
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.DateOperators;
+
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.MapMessageCountProgressionEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
+import us.dot.its.jpo.ode.api.models.IDCount;
+
+@Component
+public class MapMessageCountProgressionRepositoryImpl implements MapMessageCountProgressionEventRepository {
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    ConflictMonitorApiProperties props;
+
+    private String collectionName = "CmMapMessageCountProgressionEvents";
+
+    public Query getQuery(Integer intersectionID, Long startTime, Long endTime, boolean latest) {
+        Query query = new Query();
+
+        if (intersectionID != null) {
+            query.addCriteria(Criteria.where("intersectionID").is(intersectionID));
+        }
+        Date startTimeDate = new Date(0);
+        Date endTimeDate = new Date();
+
+        if (startTime != null) {
+            startTimeDate = new Date(startTime);
+        }
+        if (endTime != null) {
+            endTimeDate = new Date(endTime);
+        }
+
+        query.addCriteria(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate));
+        if (latest) {
+            query.with(Sort.by(Sort.Direction.DESC, "eventGeneratedAt"));
+            query.limit(1);
+        }else{
+            query.limit(props.getMaximumResponseSize());
+        }
+        return query;
+    }
+
+    public long getQueryResultCount(Query query) {
+        return mongoTemplate.count(query, MapMessageCountProgressionEvent.class, collectionName);
+    }
+
+    public long getQueryFullCount(Query query){
+        int limit = query.getLimit();
+        query.limit(-1);
+        long count = mongoTemplate.count(query, MapMessageCountProgressionEvent.class, collectionName);
+        query.limit(limit);
+        return count;
+    }
+
+    public List<MapMessageCountProgressionEvent> find(Query query) {
+        return mongoTemplate.find(query, MapMessageCountProgressionEvent.class, collectionName);
+    }
+
+    public List<IDCount> getMapMessageCountProgressionEventsByDay(int intersectionID, Long startTime, Long endTime){
+        Date startTimeDate = new Date(0);
+        Date endTimeDate = new Date();
+
+        if (startTime != null) {
+            startTimeDate = new Date(startTime);
+        }
+        if (endTime != null) {
+            endTimeDate = new Date(endTime);
+        }
+
+        Aggregation aggregation = Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
+            Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+            Aggregation.project()
+                .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("%Y-%m-%d")).as("dateStr"),
+            Aggregation.group("dateStr").count().as("count")
+        );
+
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        List<IDCount> results = result.getMappedResults();
+
+        return results;
+    }
+
+    @Override
+    public void add(MapMessageCountProgressionEvent item) {
+        mongoTemplate.save(item, collectionName);
+    }
+
+    @Override
+    public List<IDCount> getMapBroadcastRateEventsByDay(int intersectionID, Long startTime, Long endTime) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getMapBroadcastRateEventsByDay'");
+    }
+
+
+}

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/SpatMessageCountProgressionEvent/SpatMessageCountProgressionEventRepository.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/SpatMessageCountProgressionEvent/SpatMessageCountProgressionEventRepository.java
@@ -1,0 +1,21 @@
+package us.dot.its.jpo.ode.api.accessors.events.SpatMessageCountProgressionEvent;
+
+
+import java.util.List;
+
+import org.springframework.data.mongodb.core.query.Query;
+import us.dot.its.jpo.ode.api.models.IDCount;
+import us.dot.its.jpo.ode.api.models.DataLoader;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.SpatMessageCountProgressionEvent;
+
+public interface SpatMessageCountProgressionEventRepository extends DataLoader<SpatMessageCountProgressionEvent>{
+    Query getQuery(Integer intersectionID, Long startTime, Long endTime, boolean latest);
+
+    long getQueryResultCount(Query query);
+
+    long getQueryFullCount(Query query);
+    
+    List<SpatMessageCountProgressionEvent> find(Query query);
+
+    List<IDCount> getSpatBroadcastRateEventsByDay(int intersectionID, Long startTime, Long endTime);
+}

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/SpatMessageCountProgressionEvent/SpatMessageCountProgressionRepositoryImpl.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/api/accessors/events/SpatMessageCountProgressionEvent/SpatMessageCountProgressionRepositoryImpl.java
@@ -1,0 +1,114 @@
+package us.dot.its.jpo.ode.api.accessors.events.SpatMessageCountProgressionEvent;
+
+
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Component;
+
+
+import org.springframework.data.domain.Sort;
+
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.DateOperators;
+
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.SpatMessageCountProgressionEvent;
+import us.dot.its.jpo.ode.api.ConflictMonitorApiProperties;
+import us.dot.its.jpo.ode.api.models.IDCount;
+
+@Component
+public class SpatMessageCountProgressionRepositoryImpl implements SpatMessageCountProgressionEventRepository {
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    ConflictMonitorApiProperties props;
+
+    private String collectionName = "CmSpatMessageCountProgressionEvents";
+
+    public Query getQuery(Integer intersectionID, Long startTime, Long endTime, boolean latest) {
+        Query query = new Query();
+
+        if (intersectionID != null) {
+            query.addCriteria(Criteria.where("intersectionID").is(intersectionID));
+        }
+        Date startTimeDate = new Date(0);
+        Date endTimeDate = new Date();
+
+        if (startTime != null) {
+            startTimeDate = new Date(startTime);
+        }
+        if (endTime != null) {
+            endTimeDate = new Date(endTime);
+        }
+
+        query.addCriteria(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate));
+        if (latest) {
+            query.with(Sort.by(Sort.Direction.DESC, "eventGeneratedAt"));
+            query.limit(1);
+        }else{
+            query.limit(props.getMaximumResponseSize());
+        }
+        return query;
+    }
+
+    public long getQueryResultCount(Query query) {
+        return mongoTemplate.count(query, SpatMessageCountProgressionEvent.class, collectionName);
+    }
+
+    public long getQueryFullCount(Query query){
+        int limit = query.getLimit();
+        query.limit(-1);
+        long count = mongoTemplate.count(query, SpatMessageCountProgressionEvent.class, collectionName);
+        query.limit(limit);
+        return count;
+    }
+
+    public List<SpatMessageCountProgressionEvent> find(Query query) {
+        return mongoTemplate.find(query, SpatMessageCountProgressionEvent.class, collectionName);
+    }
+
+    public List<IDCount> getSpatMessageCountProgressionEventsByDay(int intersectionID, Long startTime, Long endTime){
+        Date startTimeDate = new Date(0);
+        Date endTimeDate = new Date();
+
+        if (startTime != null) {
+            startTimeDate = new Date(startTime);
+        }
+        if (endTime != null) {
+            endTimeDate = new Date(endTime);
+        }
+
+        Aggregation aggregation = Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("intersectionID").is(intersectionID)),
+            Aggregation.match(Criteria.where("eventGeneratedAt").gte(startTimeDate).lte(endTimeDate)),
+            Aggregation.project()
+                .and(DateOperators.DateToString.dateOf("eventGeneratedAt").toString("%Y-%m-%d")).as("dateStr"),
+            Aggregation.group("dateStr").count().as("count")
+        );
+
+        AggregationResults<IDCount> result = mongoTemplate.aggregate(aggregation, collectionName, IDCount.class);
+        List<IDCount> results = result.getMappedResults();
+
+        return results;
+    }
+
+    @Override
+    public void add(SpatMessageCountProgressionEvent item) {
+        mongoTemplate.save(item, collectionName);
+    }
+
+    @Override
+    public List<IDCount> getSpatBroadcastRateEventsByDay(int intersectionID, Long startTime, Long endTime) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getSpatBroadcastRateEventsByDay'");
+    }
+
+
+}

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/mockdata/MockEventGenerator.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/mockdata/MockEventGenerator.java
@@ -2,6 +2,7 @@ package us.dot.its.jpo.ode.mockdata;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -9,12 +10,15 @@ import java.util.stream.Stream;
 
 import us.dot.its.jpo.conflictmonitor.monitor.models.RegulatorIntersectionId;
 import us.dot.its.jpo.conflictmonitor.monitor.models.bsm.BsmEvent;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.BsmMessageCountProgressionEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.ConnectionOfTravelEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.IntersectionReferenceAlignmentEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.LaneDirectionOfTravelEvent;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.MapMessageCountProgressionEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.ProcessingTimePeriod;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.SignalGroupAlignmentEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.SignalStateConflictEvent;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.SpatMessageCountProgressionEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.StopLinePassageEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.StopLineStopEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.TimeChangeDetailsEvent;
@@ -176,6 +180,40 @@ public class MockEventGenerator {
         event.setNumberOfMessages(18);
         event.setTopicName("Processed Map");
         event.setTimePeriod(new ProcessingTimePeriod());
+        return event;
+    }
+
+    public static SpatMessageCountProgressionEvent getSpatMessageCountProgressionEvent() {
+        SpatMessageCountProgressionEvent event = new SpatMessageCountProgressionEvent();
+        event.setIntersectionID(12109);
+        event.setTimestampA(ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE));
+        event.setTimestampB(ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE));
+        event.setMessageType("SPaT");
+        event.setMessageCountA(0);
+        event.setMessageCountB(1);
+        return event;
+    }
+
+    public static MapMessageCountProgressionEvent getMapMessageCountProgressionEvent() {
+        MapMessageCountProgressionEvent event = new MapMessageCountProgressionEvent();
+        event.setIntersectionID(12109);
+        event.setTimestampA(ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE));
+        event.setTimestampB(ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE));
+        event.setMessageType("MAP");
+        event.setMessageCountA(0);
+        event.setMessageCountB(1);
+        return event;
+    }
+
+    public static BsmMessageCountProgressionEvent getBsmMessageCountProgressionEvent() {
+        BsmMessageCountProgressionEvent event = new BsmMessageCountProgressionEvent();
+        event.setIntersectionID(12109);
+        event.setTimestampA(ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE));
+        event.setTimestampB(ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE));
+        event.setMessageType("BSM");
+        event.setMessageCountA(0);
+        event.setMessageCountB(1);
+        event.setVehicleId(123456);
         return event;
     }
 

--- a/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/mockdata/MockEventGenerator.java
+++ b/api/jpo-conflictvisualizer-api/src/main/java/us/dot/its/jpo/ode/mockdata/MockEventGenerator.java
@@ -213,7 +213,7 @@ public class MockEventGenerator {
         event.setMessageType("BSM");
         event.setMessageCountA(0);
         event.setMessageCountB(1);
-        event.setVehicleId(123456);
+        event.setVehicleId("123ABC");
         return event;
     }
 

--- a/api/jpo-conflictvisualizer-api/src/main/resources/application.properties
+++ b/api/jpo-conflictvisualizer-api/src/main/resources/application.properties
@@ -3,12 +3,12 @@
 # Don't commit the mapbox token to github!
 
 server.port=8081
-spring.data.mongodb.database=ConflictMonitor
+spring.data.mongodb.database=CV
 spring.data.mongodb.host=${DB_HOST_IP:localhost}
 spring.data.mongodb.port=27017
-spring.data.mongodb.username=${CM_MONGO_API_USERNAME:api}
-spring.data.mongodb.password=${CM_MONGO_API_PASSWORD:api}
-spring.data.mongodb.authenticationDatabase=${CM_MONGO_AUTH_DB:CV}
+spring.data.mongodb.username=${CM_MONGO_API_USERNAME:ode}
+spring.data.mongodb.password=${CM_MONGO_API_PASSWORD:ode}
+spring.data.mongodb.authenticationDatabase=${CM_MONGO_AUTH_DB:admin}
 spring.data.mongodb.uri=${CM_MONGO_URI:null}
 
 

--- a/docker-compose-ode.yml
+++ b/docker-compose-ode.yml
@@ -28,7 +28,7 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
-
+        required: false
   # ODE Services:
   ode:
     profiles:
@@ -64,6 +64,7 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
+        required: false
     healthcheck:
       test: ["CMD", "wget" ,"--spider", "http://localhost:8080"]
       interval: 5s
@@ -99,6 +100,7 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
+        required: false
     logging:
       options:
         max-size: "10m"
@@ -132,4 +134,5 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
+        required: false
 

--- a/gui/src/apis/events-api.ts
+++ b/gui/src/apis/events-api.ts
@@ -20,6 +20,9 @@ const EVENT_TYPES: Item[] = [
   { label: "SpatMinimumDataEvent", value: "spat_minimum_data" },
   { label: "MapBroadcastRateEvent", value: "map_broadcast_rate" },
   { label: "SpatBroadcastRateEvent", value: "spat_broadcast_rate" },
+  { label: "SpatMessageCountProgressionEvent", value: "spat_message_count_progression" },
+  { label: "MapMessageCountProgressionEvent", value: "map_message_count_progression" },
+  { label: "BsmMessageCountProgressionEvent", value: "bsm_message_count_progression" },
 ];
 
 class EventsApi {

--- a/gui/src/apis/graphs-api.ts
+++ b/gui/src/apis/graphs-api.ts
@@ -18,6 +18,9 @@ class GraphsApi {
       SpatMinimumDataEventCount: 0,
       MapBroadcastRateEventCount: 0,
       SpatBroadcastRateEventCount: 0,
+      SpatMessageCountProgressionEventCount: 0,
+      MapMessageCountProgressionEventCount: 0,
+      BsmMessageCountProgressionEventCount: 0,
     };
     switch (event_type) {
       case "connection_of_travel":

--- a/gui/src/components/data-selector/data-selector-edit-form.tsx
+++ b/gui/src/components/data-selector/data-selector-edit-form.tsx
@@ -54,6 +54,9 @@ const EVENT_TYPES: Item[] = [
   { label: "SpatMinimumDataEvent", value: "spat_minimum_data" },
   { label: "MapBroadcastRateEvent", value: "map_broadcast_rate" },
   { label: "SpatBroadcastRateEvent", value: "spat_broadcast_rate" },
+  { label: "SpatMessageCountProgressionEvent", value: "spat_message_count_progression" },
+  { label: "MapMessageCountProgressionEvent", value: "map_message_count_progression" },
+  { label: "BsmMessageCountProgressionEvent", value: "bsm_message_count_progression" },
 ];
 
 const ASSESSMENT_TYPES: Item[] = [

--- a/gui/src/components/data-selector/data-visualizer.tsx
+++ b/gui/src/components/data-selector/data-visualizer.tsx
@@ -40,6 +40,9 @@ export const DataVisualizer = (props: { data: any[]; onDownload: () => void }) =
             <Line type="monotone" dataKey="SpatMinimumDataEventCount" stroke="#ff0080" />
             <Line type="monotone" dataKey="MapBroadcastRateEventCount" stroke="#0080ff" />
             <Line type="monotone" dataKey="SpatBroadcastRateEventCount" stroke="#80ff00" />
+            <Line type="monotone" dataKey="SpatMessageCountProgressionEventCount" stroke="#80ff00" />
+            <Line type="monotone" dataKey="MapMessageCountProgressionEventCount" stroke="#80ff00" />
+            <Line type="monotone" dataKey="BsmMessageCountProgressionEventCount" stroke="#80ff00" />
           </LineChart>
         </Card>
         <Box sx={{ mb: 4 }}>

--- a/gui/src/models/GraphData.d.ts
+++ b/gui/src/models/GraphData.d.ts
@@ -37,4 +37,7 @@ type EVENT_TYPES =
   | "MapMinimumDataEvent"
   | "SpatMinimumDataEvent"
   | "MapBroadcastRateEvent"
-  | "SpatBroadcastRateEvent";
+  | "SpatBroadcastRateEvent"
+    "SpatMessageCountProgressionEventCount"
+    "MapMessageCountProgressionEventCount"
+    "BsmMessageCountProgressionEventCount";

--- a/gui/src/models/jpo-conflictmonitor/events/BsmMessageCountProgressionEvent.d.ts
+++ b/gui/src/models/jpo-conflictmonitor/events/BsmMessageCountProgressionEvent.d.ts
@@ -1,0 +1,8 @@
+/// <reference path="Event.d.ts" />
+type BsmMessageCountProgressionEvent = MessageMonitor.Event & {
+    timestampA: str
+    timestampB: str
+    messageType: str
+    messageCountA: number
+    messageCountB: number
+}

--- a/gui/src/models/jpo-conflictmonitor/events/MapMessageCountProgressionEvent.d.ts
+++ b/gui/src/models/jpo-conflictmonitor/events/MapMessageCountProgressionEvent.d.ts
@@ -1,0 +1,8 @@
+/// <reference path="Event.d.ts" />
+type MapMessageCountProgressionEvent = MessageMonitor.Event & {
+    timestampA: str
+    timestampB: str
+    messageType: str
+    messageCountA: number
+    messageCountB: number
+}

--- a/gui/src/models/jpo-conflictmonitor/events/SpatMessageCountProgressionEvent.d.ts
+++ b/gui/src/models/jpo-conflictmonitor/events/SpatMessageCountProgressionEvent.d.ts
@@ -1,0 +1,8 @@
+/// <reference path="Event.d.ts" />
+type SpatMessageCountProgressionEvent = MessageMonitor.Event & {
+    timestampA: str
+    timestampB: str
+    messageType: str
+    messageCountA: number
+    messageCountB: number
+}


### PR DESCRIPTION
Adds support for message progression events to Conflict Visualizer API and GUI. This PR needs to wait until the corresponding PR in the Conflict Monitor is merged and the jar publication is updated.